### PR TITLE
Fix races in tests and code

### DIFF
--- a/drive_test.go
+++ b/drive_test.go
@@ -156,15 +156,15 @@ func TestClientDrives(t *testing.T) {
 		return
 	}
 
-	for i, uuid := range []string{"uuid-0", "uuid-1"} {
-		d := drives[i]
-
+	unprocessed := map[string]bool{"uuid-0": true, "uuid-1": true}
+	for _, d := range drives {
+		delete(unprocessed, d.UUID())
 		if d.String() == "" {
 			t.Error("Empty string representation")
 			return
 		}
 
-		testDrive(t, d, uuid, true)
+		testDrive(t, d, d.UUID(), true)
 
 		// refresh
 		if err := d.Refresh(); err != nil {
@@ -172,7 +172,7 @@ func TestClientDrives(t *testing.T) {
 			return
 		}
 
-		testDrive(t, d, uuid, false)
+		testDrive(t, d, d.UUID(), false)
 
 		if err := d.Remove(); err != nil {
 			t.Error("Drive remove fail:", err)
@@ -184,6 +184,9 @@ func TestClientDrives(t *testing.T) {
 			t.Error("Drive refresh must fail")
 			return
 		}
+	}
+	if len(unprocessed) > 0 {
+		t.Error("not all drives created")
 	}
 
 	mock.ResetDrives()

--- a/https/httpstest/response.go
+++ b/https/httpstest/response.go
@@ -11,9 +11,24 @@ import (
 	"time"
 )
 
+type readerCloser struct {
+	*strings.Reader
+}
+
+func (*readerCloser) Close() error {
+	return nil
+}
+
 // CreateResponse creates test response from HTTP code
 func CreateResponse(code int) (*http.Response, error) {
 	dateTime := time.Now().UTC().Format(time.RFC1123)
+	if code == 0 {
+		resp := &http.Response{
+			StatusCode: 0,
+			Body:       &readerCloser{strings.NewReader("")},
+		}
+		return resp, nil
+	}
 	msg := fmt.Sprintf(`HTTP/1.1 %d %s
 Server: cloudflare-nginx
 Date: %s

--- a/job_test.go
+++ b/job_test.go
@@ -120,7 +120,7 @@ func TestJobProgress(t *testing.T) {
 	}
 
 	setJobProgress := func() {
-		jd.Data.Progress = 100
+		mock.Jobs.SetProgress(jd.UUID, 100)
 	}
 	go setJobProgress()
 

--- a/mock/drives.go
+++ b/mock/drives.go
@@ -151,7 +151,7 @@ func (d *DriveLibrary) Clone(uuid string, params map[string]interface{}) (string
 		defer Jobs.s.Unlock()
 		job.Data.Progress = 100
 		job.State = "success"
-		newDrive.Status = "unmounted"
+		d.SetStatus(newDrive.UUID, "unmounted")
 	}
 	go cloning()
 

--- a/mock/id_test.go
+++ b/mock/id_test.go
@@ -6,9 +6,6 @@ package mock
 import "testing"
 
 func TestMockGenerateID(t *testing.T) {
-
-	t.Parallel()
-
 	for i := 0; i < 10; i++ {
 		if v := genID(); v != i {
 			t.Errorf("ID at %d should be equal to %d", i, v)

--- a/mock/jobs.go
+++ b/mock/jobs.go
@@ -101,6 +101,17 @@ func (j *JobLibrary) SetState(uuid, state string) {
 	}
 }
 
+// SetProgress for the job in the library
+func (j *JobLibrary) SetProgress(uuid string, progress int) {
+	j.s.Lock()
+	defer j.s.Unlock()
+
+	job, ok := j.m[uuid]
+	if ok {
+		job.Data.Progress = progress
+	}
+}
+
 func (j *JobLibrary) handleRequest(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimSuffix(r.URL.Path, "/")
 	path = strings.TrimPrefix(path, j.p)


### PR DESCRIPTION
go test -race ./... shows various races which are fixed in this PR.
Also make tweaks to httptest.CreateResponse() for Go 1.8 compatibility.